### PR TITLE
[Features] Operands as Strings, Decimal Point Button

### DIFF
--- a/tests/MainTests.elm
+++ b/tests/MainTests.elm
@@ -22,6 +22,22 @@ extractLeftHandSide model =
             left
 
 
+extractRightHandSide : Main.Model -> Maybe String
+extractRightHandSide model =
+    case model of
+        Main.LeftHandSide left ->
+            Nothing
+
+        Main.AwaitingRightHandSide _ left ->
+            Nothing
+
+        Main.ReadyToEvaluate ( _, _, right ) ->
+            Just right
+
+        Main.Evaluated ( _, _, right ) _ ->
+            Just right
+
+
 executeNTimes : Int -> (a -> a) -> a -> a
 executeNTimes n func arg =
     case n of
@@ -49,7 +65,16 @@ suite =
             , test "Constrains to 16 digits long" (\_ -> Main.incrementOperand "123456789123456789" "1" |> Expect.equal "1234567891234567")
             , test "Constrains to 16 digits long favoring current operand" (\_ -> Main.incrementOperand "1" "123456789123456789" |> Expect.equal "1")
             ]
-        , describe "update"
+        , describe "Main.mutate Negate"
+            [ test "Changes a positive operand to negative" (\_ -> Main.mutate Main.Negate "1" |> Expect.equal "-1")
+            , test "Changes a negative operand to positive" (\_ -> Main.mutate Main.Negate "-1" |> Expect.equal "1")
+            , test "Does not negate zero" (\_ -> Main.mutate Main.Negate "0" |> Expect.equal "0")
+            ]
+        , describe "Main.mutate AppendDecimalPoint"
+            [ test "Adds a decimal point to the operand" (\_ -> Main.mutate Main.AppendDecimalPoint "0" |> Expect.equal "0.")
+            , test "Does not add a decimal point if there already is one" (\_ -> Main.mutate Main.AppendDecimalPoint "1.2" |> Expect.equal "1.2")
+            ]
+        , describe "Main.update"
             [ fuzz float
                 "Increasing left hand side from 0"
                 (\float ->
@@ -74,6 +99,32 @@ suite =
                         |> Main.update (Main.OperandPressed "2")
                         |> extractLeftHandSide
                         |> Expect.equal (Main.incrementOperand operand "2")
+                )
+            , fuzz float
+                "Negating the left hand side"
+                (\float ->
+                    let
+                        operand =
+                            String.fromFloat float
+                    in
+                    Main.init
+                        |> Main.update (Main.OperandPressed operand)
+                        |> Main.update (Main.MutatorPressed Main.Negate)
+                        |> extractLeftHandSide
+                        |> Expect.equal (Main.mutate Main.Negate operand)
+                )
+            , fuzz int
+                "Appending a decimal point to the lefthand side"
+                (\integer ->
+                    let
+                        operand =
+                            String.fromInt integer
+                    in
+                    Main.init
+                        |> Main.update (Main.OperandPressed operand)
+                        |> Main.update (Main.MutatorPressed Main.AppendDecimalPoint)
+                        |> extractLeftHandSide
+                        |> Expect.equal (Main.mutate Main.AppendDecimalPoint operand)
                 )
             , fuzz float
                 "Adding an operator"
@@ -101,6 +152,40 @@ suite =
                         |> Main.update (Main.OperatorPressed Main.Add)
                         |> Main.update (Main.OperandPressed "2")
                         |> Expect.equal (Main.ReadyToEvaluate ( Main.Add, Main.incrementOperand operand "2", "2" ))
+                )
+            , fuzz float
+                "Negating the right hand side"
+                (\float ->
+                    let
+                        operand =
+                            String.fromFloat float
+                    in
+                    Main.init
+                        |> Main.update (Main.OperandPressed operand)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperatorPressed Main.Add)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.MutatorPressed Main.Negate)
+                        |> extractRightHandSide
+                        |> Maybe.withDefault "0"
+                        |> Expect.equal (Main.mutate Main.Negate "2")
+                )
+            , fuzz int
+                "Appending a decimal point to the right hand side"
+                (\integer ->
+                    let
+                        operand =
+                            String.fromInt integer
+                    in
+                    Main.init
+                        |> Main.update (Main.OperandPressed operand)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperatorPressed Main.Add)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.MutatorPressed Main.AppendDecimalPoint)
+                        |> extractRightHandSide
+                        |> Maybe.withDefault "0"
+                        |> Expect.equal (Main.mutate Main.AppendDecimalPoint "2")
                 )
             , fuzz float
                 "Evaluating an operation"
@@ -170,6 +255,64 @@ suite =
                         |> Main.update (Main.OperatorPressed Main.Multiply)
                         |> Main.update (Main.OperatorPressed Main.Equals)
                         |> Expect.equal (Main.Evaluated ( Main.Multiply, "44", "44" ) (Main.evaluate ( Main.Multiply, "44", "44" )))
+                )
+            , test
+                "Negating the result of an evaluated operation"
+                (\_ ->
+                    Main.init
+                        |> Main.update (Main.OperandPressed "4")
+                        |> Main.update (Main.OperandPressed "4")
+                        |> Main.update (Main.OperatorPressed Main.Divide)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperatorPressed Main.Equals)
+                        |> Main.update (Main.MutatorPressed Main.Negate)
+                        |> Expect.equal (Main.Evaluated ( Main.Divide, "44", "2" ) "-22")
+                )
+            , test
+                "Evaluating a operation using the negated result of a previous operation"
+                (\_ ->
+                    Main.init
+                        |> Main.update (Main.OperandPressed "4")
+                        |> Main.update (Main.OperandPressed "4")
+                        |> Main.update (Main.OperatorPressed Main.Divide)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperatorPressed Main.Equals)
+                        |> Main.update (Main.MutatorPressed Main.Negate)
+                        |> Main.update (Main.OperatorPressed Main.Add)
+                        |> Main.update (Main.OperandPressed "5")
+                        |> Main.update (Main.OperatorPressed Main.Equals)
+                        |> Expect.equal (Main.Evaluated ( Main.Add, "-22", "5" ) "-17")
+                )
+            , test
+                "Appending a decimal point after evaluating an operation starts a new operation"
+                (\_ ->
+                    Main.init
+                        |> Main.update (Main.OperandPressed "4")
+                        |> Main.update (Main.OperandPressed "4")
+                        |> Main.update (Main.OperatorPressed Main.Divide)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperatorPressed Main.Equals)
+                        |> Main.update (Main.MutatorPressed Main.AppendDecimalPoint)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Expect.equal (Main.LeftHandSide "0.22")
+                )
+            , test
+                "Evaluating a new operation after starting a new one with appending a decimal point"
+                (\_ ->
+                    Main.init
+                        |> Main.update (Main.OperandPressed "4")
+                        |> Main.update (Main.OperandPressed "4")
+                        |> Main.update (Main.OperatorPressed Main.Divide)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperatorPressed Main.Equals)
+                        |> Main.update (Main.MutatorPressed Main.AppendDecimalPoint)
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperandPressed "2")
+                        |> Main.update (Main.OperatorPressed Main.Add)
+                        |> Main.update (Main.OperandPressed "5")
+                        |> Main.update (Main.OperatorPressed Main.Equals)
+                        |> Expect.equal (Main.Evaluated ( Main.Add, "0.22", "5" ) "5.22")
                 )
             , test
                 "A user cannot create an operand longer than 16 digits"


### PR DESCRIPTION
Converts the application to use Strings instead of floats, adds the decimal point button.

When experimenting with how best to implement the decimal point button I realized that the simplest way forward was to use Strings instead of Floats.
While this feels a bit dodgy, it kept things simple and straightforward.