### PR TITLE
[Refactor] Evaluate operations with prikhi/decimal

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,15 +11,19 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm-explorations/test": "1.2.2",
+            "prikhi/decimal": "2.0.0",
             "rtfeldman/elm-css": "16.0.1"
         },
         "indirect": {
             "Skinney/murmur3": "2.0.8",
+            "cmditch/elm-bigint": "1.0.1",
             "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
+            "elm-community/list-extra": "8.2.4",
+            "elm-community/maybe-extra": "5.2.0",
             "elm-community/random-extra": "3.1.0",
             "owanturist/elm-union-find": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -16,6 +16,7 @@ module Main exposing
 import Browser
 import Css
 import Css.Global
+import Decimal exposing (Decimal)
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Html
 import Html.Styled.Events exposing (onClick)
@@ -175,29 +176,33 @@ evaluate : Operation -> String
 evaluate ( operator, left, right ) =
     let
         lhs =
-            String.toFloat left |> Maybe.withDefault 0
+            left |> Decimal.fromString |> Maybe.withDefault Decimal.zero
 
         rhs =
-            String.toFloat right |> Maybe.withDefault 0
-
-        result =
-            case operator of
-                Add ->
-                    lhs + rhs
-
-                Multiply ->
-                    lhs * rhs
-
-                Subtract ->
-                    lhs - rhs
-
-                Divide ->
-                    lhs / rhs
-
-                Equals ->
-                    rhs
+            right |> Decimal.fromString |> Maybe.withDefault Decimal.zero
     in
-    result |> String.fromFloat
+    case operator of
+        Add ->
+            Decimal.add lhs rhs |> Decimal.toString
+
+        Multiply ->
+            Decimal.mul lhs rhs |> Decimal.toString
+
+        Subtract ->
+            Decimal.sub lhs rhs |> Decimal.toString
+
+        Divide ->
+            if isZero right then
+                "Infinity"
+
+            else
+                rhs
+                    |> Decimal.fastdiv lhs
+                    |> Maybe.withDefault Decimal.zero
+                    |> Decimal.toString
+
+        Equals ->
+            rhs |> Decimal.toString
 
 
 mutate : Mutator -> String -> String


### PR DESCRIPTION
Floating point percision can be weird!
e.g: 0.1 + 0.2 = 0.30000000000000004

Using a arbitrarily precise Decimal numbers avoids the weirdness.

This does add some complications. Namely this library manages divison
and division by zero differently. Division returns a Maybe type, and
returns Maybe Decimal 0 for division by zero.

In all cases where a maybe returns Nothing I'm blindly converting to 0.
This doesn't seem great, but I haven't thought of a better way to manage
this yet. At least it keeps us in the realm of numbers.