### PR TITLE
Refactor to use Strings & Decimals instead of Ints

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -24,11 +24,11 @@ main =
 
 
 type Input
-    = InputLeft Int
-    | NeedRight Int
-    | InputRight Int
-    | EagerEvaluated Int
-    | Evaluated Int
+    = InputLeft String
+    | NeedRight String
+    | InputRight String
+    | EagerEvaluated String
+    | Evaluated String
     | Empty
 
 
@@ -36,7 +36,7 @@ type alias Model =
     { input : Input
     , yard : ShuntingYard
     , previous : ShuntingYard
-    , evaluated : Result String Int
+    , evaluated : Result String String
     }
 
 
@@ -50,7 +50,7 @@ init =
 
 
 type Msg
-    = OperandPressed Int
+    = OperandPressed String
     | OperatorPressed OperatorType
     | EqualsPressed
 
@@ -84,9 +84,9 @@ update msg model =
                     case model.input of
                         Empty ->
                             ( model.yard
-                                |> ShuntingYard.appendOperand 0
+                                |> ShuntingYard.appendOperand "0"
                                 |> ShuntingYard.appendOperator operator
-                            , NeedRight 0
+                            , NeedRight "0"
                             )
 
                         InputLeft left ->
@@ -134,7 +134,7 @@ update msg model =
                     case model.input of
                         Empty ->
                             ( model.yard
-                            , Evaluated 0
+                            , Evaluated "0"
                             )
 
                         InputLeft operand ->
@@ -189,19 +189,10 @@ update msg model =
                     { model | input = input, evaluated = Err m }
 
 
-incrementOperand : Int -> Int -> Int
-incrementOperand c n =
-    let
-        current =
-            String.fromInt c
-
-        new =
-            String.fromInt n
-    in
+incrementOperand : String -> String -> String
+incrementOperand current new =
     if current == "0" then
         new
-            |> String.toInt
-            |> Maybe.withDefault 0
 
     else
         let
@@ -209,21 +200,19 @@ incrementOperand c n =
                 current ++ new
         in
         if String.length newValString > 16 then
-            current |> String.slice 0 16 |> String.toInt |> Maybe.withDefault 0
+            current |> String.slice 0 16
 
         else
             newValString
-                |> String.toInt
-                |> Maybe.withDefault 0
 
 
 
 -- VIEW
 
 
-allOperands : List Int
+allOperands : List String
 allOperands =
-    [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 ]
+    [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" ]
 
 
 viewEvaluation : Input -> String
@@ -233,19 +222,19 @@ viewEvaluation input =
             "0"
 
         InputLeft operand ->
-            String.fromInt operand
+            operand
 
         NeedRight operand ->
-            String.fromInt operand
+            operand
 
         InputRight operand ->
-            String.fromInt operand
+            operand
 
         EagerEvaluated result ->
-            String.fromInt result
+            result
 
         Evaluated result ->
-            String.fromInt result
+            result
 
 
 view : Model -> Html Msg
@@ -282,12 +271,12 @@ displayTotalCss =
     ]
 
 
-cardView : Int -> ( String, Html Msg )
+cardView : String -> ( String, Html Msg )
 cardView operand =
-    ( "card" ++ String.fromInt operand
+    ( "card" ++ operand
     , Html.div
         [ onClick (OperandPressed operand) ]
-        [ Html.text (String.fromInt operand) ]
+        [ Html.text operand ]
     )
 
 

--- a/src/Operator.elm
+++ b/src/Operator.elm
@@ -1,5 +1,6 @@
 module Operator exposing (OperatorType(..), calculate, findLesserOperators, findPrecedentOperators, toString)
 
+import Decimal
 import List.Extra
 
 
@@ -36,20 +37,39 @@ precedence operator =
             1
 
 
-calculate : OperatorType -> Int -> Int -> Int
+calculate : OperatorType -> String -> String -> String
 calculate operator left right =
+    let
+        lhs =
+            left |> Decimal.fromString |> Maybe.withDefault Decimal.zero
+
+        rhs =
+            right |> Decimal.fromString |> Maybe.withDefault Decimal.zero
+    in
     case operator of
         Add ->
-            left + right
-
-        Subtract ->
-            left - right
-
-        Divide ->
-            left // right
+            Decimal.add lhs rhs |> Decimal.toString
 
         Multiply ->
-            left * right
+            Decimal.mul lhs rhs |> Decimal.toString
+
+        Subtract ->
+            Decimal.sub lhs rhs |> Decimal.toString
+
+        Divide ->
+            if isZero right then
+                "Infinity"
+
+            else
+                rhs
+                    |> Decimal.fastdiv lhs
+                    |> Maybe.withDefault Decimal.zero
+                    |> Decimal.toString
+
+
+isZero : String -> Bool
+isZero operand =
+    operand |> String.toFloat |> Maybe.withDefault 0 |> (==) 0
 
 
 takesPrecedence : OperatorType -> OperatorType -> Bool

--- a/src/RPNExpression.elm
+++ b/src/RPNExpression.elm
@@ -4,7 +4,7 @@ import Operator exposing (OperatorType, calculate)
 
 
 type Token
-    = Operand Int
+    = Operand String
     | Operator OperatorType
 
 
@@ -17,7 +17,7 @@ emptyExpression =
     []
 
 
-appendOperand : Int -> RPNExpression -> RPNExpression
+appendOperand : String -> RPNExpression -> RPNExpression
 appendOperand operand expression =
     expression ++ [ Operand operand ]
 
@@ -27,13 +27,13 @@ appendOperator operator expression =
     expression ++ [ Operator operator ]
 
 
-currentOperand : RPNExpression -> Int
+currentOperand : RPNExpression -> String
 currentOperand expression =
     let
         findOperand exp =
             case exp of
                 [] ->
-                    0
+                    "0"
 
                 (Operand operand) :: _ ->
                     operand
@@ -46,7 +46,7 @@ currentOperand expression =
         |> findOperand
 
 
-evaluate : RPNExpression -> Result String Int
+evaluate : RPNExpression -> Result String String
 evaluate expression =
     let
         evaluateFunc exp stack =
@@ -83,8 +83,8 @@ toString =
         << List.map
             (\token ->
                 case token of
-                    Operand int ->
-                        String.fromInt int
+                    Operand operand ->
+                        operand
 
                     Operator operator ->
                         Operator.toString operator

--- a/src/ShuntingYard.elm
+++ b/src/ShuntingYard.elm
@@ -31,7 +31,7 @@ init =
     ShuntingYard RPN.emptyExpression []
 
 
-appendOperand : Int -> ShuntingYard -> ShuntingYard
+appendOperand : String -> ShuntingYard -> ShuntingYard
 appendOperand operand (ShuntingYard expression operatorStack) =
     ShuntingYard (RPN.appendOperand operand expression) operatorStack
 
@@ -61,12 +61,12 @@ replaceCurrentOperator operator (ShuntingYard expression operatorStack) =
             ShuntingYard expression (operator :: tail)
 
 
-evaluate : ShuntingYard -> Result String Int
+evaluate : ShuntingYard -> Result String String
 evaluate (ShuntingYard expression operatorStack) =
     RPN.evaluate (List.foldl RPN.appendOperator expression operatorStack)
 
 
-preemptiveEvaluate : ShuntingYard -> Result String Int
+preemptiveEvaluate : ShuntingYard -> Result String String
 preemptiveEvaluate (ShuntingYard expression operatorStack) =
     expression
         |> List.reverse
@@ -85,7 +85,7 @@ shiftCurrentOperandToExpression (ShuntingYard expression operatorStack) =
             ShuntingYard (RPN.appendOperator operator expression) operatorsTail
 
 
-currentOperand : ShuntingYard -> Int
+currentOperand : ShuntingYard -> String
 currentOperand (ShuntingYard expression operatorStack) =
     RPN.currentOperand expression
 

--- a/tests/MainTests.elm
+++ b/tests/MainTests.elm
@@ -12,189 +12,189 @@ suite : Test
 suite =
     describe "The Main Module"
         [ describe "incrementOperand"
-            [ test "Increments an integer value" (\_ -> incrementOperand 1 1 |> Expect.equal 11)
-            , test "Increments from 0" (\_ -> incrementOperand 0 4 |> Expect.equal 4)
-            , test "Constrains to 16 digits long" (\_ -> incrementOperand 123456789123456789 1 |> Expect.equal 1234567891234567)
-            , test "Constrains to 16 digits long favoring current operand" (\_ -> incrementOperand 1 123456789123456789 |> Expect.equal 1)
+            [ test "Increments an integer value" (\_ -> incrementOperand "1" "1" |> Expect.equal "11")
+            , test "Increments from 0" (\_ -> incrementOperand "0" "4" |> Expect.equal "4")
+            , test "Constrains to 16 digits long" (\_ -> incrementOperand "123456789123456789" "1" |> Expect.equal "1234567891234567")
+            , test "Constrains to 16 digits long favoring current operand" (\_ -> incrementOperand "1" "123456789123456789" |> Expect.equal "1")
             ]
         , describe "update"
             [ test "Inputting left hand side"
                 (\_ ->
                     init
-                        |> update (OperandPressed 1)
-                        |> update (OperandPressed 5)
+                        |> update (OperandPressed "1")
+                        |> update (OperandPressed "5")
                         |> (\{ input } -> input)
-                        |> Expect.equal (InputLeft 15)
+                        |> Expect.equal (InputLeft "15")
                 )
             , test "Inputting an operator after a left hand side"
                 (\_ ->
                     init
-                        |> update (OperandPressed 1)
-                        |> update (OperandPressed 5)
+                        |> update (OperandPressed "1")
+                        |> update (OperandPressed "5")
                         |> update (OperatorPressed Divide)
                         |> (\{ input } -> input)
-                        |> Expect.equal (NeedRight 15)
+                        |> Expect.equal (NeedRight "15")
                 )
             , test "Inputting an operand after an operator"
                 (\_ ->
                     init
-                        |> update (OperandPressed 1)
-                        |> update (OperandPressed 5)
+                        |> update (OperandPressed "1")
+                        |> update (OperandPressed "5")
                         |> update (OperatorPressed Divide)
-                        |> update (OperandPressed 5)
+                        |> update (OperandPressed "5")
                         |> (\{ input } -> input)
-                        |> Expect.equal (InputRight 5)
+                        |> Expect.equal (InputRight "5")
                 )
             , test "Evaluating an expression"
                 (\_ ->
                     init
-                        |> update (OperandPressed 1)
-                        |> update (OperandPressed 5)
+                        |> update (OperandPressed "1")
+                        |> update (OperandPressed "5")
                         |> update (OperatorPressed Divide)
-                        |> update (OperandPressed 5)
+                        |> update (OperandPressed "5")
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 3)
+                        |> Expect.equal (Evaluated "3")
                 )
             , test "Repeating an evaluation"
                 (\_ ->
                     init
-                        |> update (OperandPressed 4)
-                        |> update (OperandPressed 8)
+                        |> update (OperandPressed "4")
+                        |> update (OperandPressed "8")
                         |> update (OperatorPressed Divide)
-                        |> update (OperandPressed 2)
+                        |> update (OperandPressed "2")
                         |> update EqualsPressed
                         |> update EqualsPressed
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 6)
+                        |> Expect.equal (Evaluated "6")
                 )
             , test "Evaluating a new expression after evaluation"
                 (\_ ->
                     init
-                        |> update (OperandPressed 4)
-                        |> update (OperandPressed 8)
+                        |> update (OperandPressed "4")
+                        |> update (OperandPressed "8")
                         |> update (OperatorPressed Divide)
-                        |> update (OperandPressed 2)
+                        |> update (OperandPressed "2")
                         |> update EqualsPressed
-                        |> update (OperandPressed 2)
+                        |> update (OperandPressed "2")
                         |> update (OperatorPressed Multiply)
-                        |> update (OperandPressed 8)
-                        |> update (OperandPressed 8)
+                        |> update (OperandPressed "8")
+                        |> update (OperandPressed "8")
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 176)
+                        |> Expect.equal (Evaluated "176")
                 )
             , test "Evaluating an expression without entering a left hand side operand"
                 (\_ ->
                     init
                         |> update (OperatorPressed Add)
-                        |> update (OperandPressed 2)
-                        |> update (OperandPressed 2)
-                        |> update (OperandPressed 8)
+                        |> update (OperandPressed "2")
+                        |> update (OperandPressed "2")
+                        |> update (OperandPressed "8")
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 228)
+                        |> Expect.equal (Evaluated "228")
                 )
             , test "Changing the current operator"
                 (\_ ->
                     init
-                        |> update (OperandPressed 1)
-                        |> update (OperandPressed 6)
+                        |> update (OperandPressed "1")
+                        |> update (OperandPressed "6")
                         |> update (OperatorPressed Add)
                         |> update (OperatorPressed Divide)
-                        |> update (OperandPressed 8)
+                        |> update (OperandPressed "8")
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 2)
+                        |> Expect.equal (Evaluated "2")
                 )
             , test "Chaining operations"
                 (\_ ->
                     init
-                        |> update (OperandPressed 3)
+                        |> update (OperandPressed "3")
                         |> update (OperatorPressed Add)
-                        |> update (OperandPressed 4)
+                        |> update (OperandPressed "4")
                         |> update (OperatorPressed Multiply)
-                        |> update (OperandPressed 2)
+                        |> update (OperandPressed "2")
                         |> update (OperatorPressed Divide)
-                        |> update (OperandPressed 2)
+                        |> update (OperandPressed "2")
                         |> update (OperatorPressed Add)
-                        |> update (OperandPressed 3)
+                        |> update (OperandPressed "3")
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 10)
+                        |> Expect.equal (Evaluated "10")
                 )
             , test "Reusing the right hand side of a previous operation"
                 (\_ ->
                     init
-                        |> update (OperandPressed 4)
-                        |> update (OperandPressed 8)
+                        |> update (OperandPressed "4")
+                        |> update (OperandPressed "8")
                         |> update (OperatorPressed Divide)
-                        |> update (OperandPressed 2)
+                        |> update (OperandPressed "2")
                         |> update EqualsPressed
-                        |> update (OperandPressed 8)
-                        |> update (OperandPressed 8)
+                        |> update (OperandPressed "8")
+                        |> update (OperandPressed "8")
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 44)
+                        |> Expect.equal (Evaluated "44")
                 )
             , test "Using the result of an operation as the left hand side of a new operation"
                 (\_ ->
                     init
-                        |> update (OperandPressed 5)
-                        |> update (OperandPressed 5)
+                        |> update (OperandPressed "5")
+                        |> update (OperandPressed "5")
                         |> update (OperatorPressed Divide)
-                        |> update (OperandPressed 5)
+                        |> update (OperandPressed "5")
                         |> update EqualsPressed
                         |> update (OperatorPressed Add)
-                        |> update (OperandPressed 3)
+                        |> update (OperandPressed "3")
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 14)
+                        |> Expect.equal (Evaluated "14")
                 )
             , test "Changing operator after eager evaluation"
                 (\_ ->
                     init
-                        |> update (OperandPressed 3)
+                        |> update (OperandPressed "3")
                         |> update (OperatorPressed Add)
-                        |> update (OperandPressed 4)
+                        |> update (OperandPressed "4")
                         |> update (OperatorPressed Multiply)
-                        |> update (OperandPressed 2)
+                        |> update (OperandPressed "2")
                         |> update (OperatorPressed Divide)
                         |> update (OperatorPressed Multiply)
-                        |> update (OperandPressed 6)
+                        |> update (OperandPressed "6")
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 51)
+                        |> Expect.equal (Evaluated "51")
                 )
             , test "Evaluating an empty input"
                 (\_ ->
                     init
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 0)
+                        |> Expect.equal (Evaluated "0")
                 )
             , test "Evaluation Shortcut"
                 (\_ ->
                     init
-                        |> update (OperandPressed 3)
+                        |> update (OperandPressed "3")
                         |> update (OperatorPressed Add)
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 6)
+                        |> Expect.equal (Evaluated "6")
                 )
             , test "Evaluating after eager evaluation"
                 (\_ ->
                     init
-                        |> update (OperandPressed 3)
+                        |> update (OperandPressed "3")
                         |> update (OperatorPressed Add)
-                        |> update (OperandPressed 4)
+                        |> update (OperandPressed "4")
                         |> update (OperatorPressed Multiply)
-                        |> update (OperandPressed 2)
+                        |> update (OperandPressed "2")
                         |> update (OperatorPressed Divide)
                         |> update EqualsPressed
                         |> (\{ input } -> input)
-                        |> Expect.equal (Evaluated 8)
+                        |> Expect.equal (Evaluated "8.375")
                 )
             ]
         ]

--- a/tests/OperatorTests.elm
+++ b/tests/OperatorTests.elm
@@ -12,19 +12,19 @@ suite =
             [ test
                 "It performs addition"
                 (\_ ->
-                    calculate Add 4 5 |> Expect.equal 9
+                    calculate Add "4" "5" |> Expect.equal "9"
                 )
             , test "It performs substraction"
                 (\_ ->
-                    calculate Subtract 4 5 |> Expect.equal -1
+                    calculate Subtract "4" "5" |> Expect.equal "-1"
                 )
             , test "It performs multiplication"
                 (\_ ->
-                    calculate Multiply 4 5 |> Expect.equal 20
+                    calculate Multiply "4" "5" |> Expect.equal "20"
                 )
-            , test "It performs integer division"
+            , test "It performs decimal division"
                 (\_ ->
-                    calculate Divide 4 5 |> Expect.equal 0
+                    calculate Divide "4" "5" |> Expect.equal "0.8"
                 )
             ]
         , describe "findPrecedentOperators"

--- a/tests/RPNExpressionTest.elm
+++ b/tests/RPNExpressionTest.elm
@@ -14,8 +14,8 @@ suite =
                 "It appends the given operand to the end of the expression"
                 (\_ ->
                     emptyExpression
-                        |> appendOperand 3
-                        |> appendOperand 4
+                        |> appendOperand "3"
+                        |> appendOperand "4"
                         |> RPNExpression.toString
                         |> Expect.equal "3 4"
                 )
@@ -25,12 +25,12 @@ suite =
                 "It appends the given operator to the end of the expression"
                 (\_ ->
                     emptyExpression
-                        |> appendOperand 3
-                        |> appendOperand 7
+                        |> appendOperand "3"
+                        |> appendOperand "7"
                         |> appendOperator Add
-                        |> appendOperand 6
+                        |> appendOperand "6"
                         |> appendOperator Subtract
-                        |> appendOperand 2
+                        |> appendOperand "2"
                         |> appendOperator Divide
                         |> RPNExpression.toString
                         |> Expect.equal "3 7 + 6 - 2 ÷"
@@ -41,60 +41,56 @@ suite =
                 "It returns the last operand in the expression"
                 (\_ ->
                     emptyExpression
-                        |> appendOperand 3
-                        |> appendOperand 4
+                        |> appendOperand "3"
+                        |> appendOperand "4"
                         |> appendOperator Add
                         |> currentOperand
-                        |> Expect.equal 4
+                        |> Expect.equal "4"
                 )
             ]
         , describe "evaluate"
             [ test "It correctly evaluates a valid RPN expression"
                 (\_ ->
                     emptyExpression
-                        |> appendOperand 3
-                        |> appendOperand 4
+                        |> appendOperand "3"
+                        |> appendOperand "4"
                         |> appendOperator Add
                         |> evaluate
-                        |> Result.map String.fromInt
                         |> Result.withDefault "error"
                         |> Expect.equal "7"
                 )
             , test "It correctly evaluates a more complex RPN expression"
                 (\_ ->
                     emptyExpression
-                        |> appendOperand 60
-                        |> appendOperand 5
+                        |> appendOperand "60"
+                        |> appendOperand "5"
                         |> appendOperator Divide
-                        |> appendOperand 19
+                        |> appendOperand "19"
                         |> appendOperator Multiply
-                        |> appendOperand 10
+                        |> appendOperand "10"
                         |> appendOperator Add
                         |> evaluate
-                        |> Result.map String.fromInt
                         |> Result.withDefault "error"
                         |> Expect.equal "238"
                 )
             , test "It returns an error for an invalid RPN expression, too few operators"
                 (\_ ->
                     emptyExpression
-                        |> appendOperand 60
-                        |> appendOperand 5
+                        |> appendOperand "60"
+                        |> appendOperand "5"
                         |> appendOperator Divide
-                        |> appendOperand 19
+                        |> appendOperand "19"
                         |> appendOperator Multiply
-                        |> appendOperand 10
+                        |> appendOperand "10"
                         |> evaluate
-                        |> Result.map String.fromInt
                         |> Expect.equal (Err "Evaluation Failure: Too Few Operators")
                 )
             , test "It returns an error for an invalid RPN expression, expression too short"
                 (\_ ->
                     emptyExpression
-                        |> appendOperand 60
+                        |> appendOperand "60"
                         |> appendOperator Divide
                         |> evaluate
-                        |> Result.map String.fromInt
                         |> Expect.equal (Err "Evaluation Failure: Expression Too Short")
                 )
             ]

--- a/tests/ShuntingYardTests.elm
+++ b/tests/ShuntingYardTests.elm
@@ -15,8 +15,8 @@ suite =
                 "It appends an operand to its expression"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 5
-                        |> SY.appendOperand 66
+                        |> SY.appendOperand "5"
+                        |> SY.appendOperand "66"
                         |> SY.extractExpression
                         |> RPN.toString
                         |> Expect.equal "5 66"
@@ -26,7 +26,7 @@ suite =
             [ test "It appends an operator to an empty stack"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Add
                         |> SY.extractOperatorStack
                         |> Expect.equal [ Add ]
@@ -34,9 +34,9 @@ suite =
             , test "It appends higher precedence operators to a stack if the first operator is of lesser precedence"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Add
-                        |> SY.appendOperand 5
+                        |> SY.appendOperand "5"
                         |> SY.appendOperator Multiply
                         |> SY.extractOperatorStack
                         |> Expect.equal [ Multiply, Add ]
@@ -44,11 +44,11 @@ suite =
             , test "It removes higher precedence operators from the stack"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Add
-                        |> SY.appendOperand 5
+                        |> SY.appendOperand "5"
                         |> SY.appendOperator Multiply
-                        |> SY.appendOperand 3
+                        |> SY.appendOperand "3"
                         |> SY.appendOperator Divide
                         |> SY.extractOperatorStack
                         |> Expect.equal [ Divide, Add ]
@@ -56,11 +56,11 @@ suite =
             , test "It shifts higher precedence operators from the stack to the expression"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Add
-                        |> SY.appendOperand 5
+                        |> SY.appendOperand "5"
                         |> SY.appendOperator Multiply
-                        |> SY.appendOperand 3
+                        |> SY.appendOperand "3"
                         |> SY.appendOperator Divide
                         |> SY.extractExpression
                         |> RPN.toString
@@ -71,7 +71,7 @@ suite =
             [ test "It replaces the head operator of stack"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Add
                         |> SY.replaceCurrentOperator Subtract
                         |> SY.extractOperatorStack
@@ -80,7 +80,7 @@ suite =
             , test "It inserts an operator to an empty stack"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.replaceCurrentOperator Subtract
                         |> SY.extractOperatorStack
                         |> Expect.equal [ Subtract ]
@@ -90,38 +90,37 @@ suite =
             [ test "It evaluates the underlying RPN Expression"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Multiply
-                        |> SY.appendOperand 9
+                        |> SY.appendOperand "9"
                         |> SY.evaluate
-                        |> Result.withDefault 0
-                        |> Expect.equal 36
+                        |> Result.withDefault "0"
+                        |> Expect.equal "36"
                 )
             ]
         , describe "preemptiveEvaluate"
             [ test "It attempts to evaluate the last 3 tokens of the expression"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 3
+                        |> SY.appendOperand "3"
                         |> SY.appendOperator Add
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Multiply
-                        |> SY.appendOperand 2
+                        |> SY.appendOperand "2"
                         |> SY.appendOperator Divide
                         |> SY.preemptiveEvaluate
-                        |> Result.withDefault 0
-                        |> Expect.equal 8
+                        |> Result.withDefault "0"
+                        |> Expect.equal "8"
                 )
             , test "It fails gracefully for invalid expression"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 3
+                        |> SY.appendOperand "3"
                         |> SY.appendOperator Add
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Multiply
-                        |> SY.appendOperand 2
+                        |> SY.appendOperand "2"
                         |> SY.preemptiveEvaluate
-                        |> Result.map String.fromInt
                         |> Expect.equal (Err "Evaluation Failure: Too Few Operators")
                 )
             ]
@@ -129,47 +128,47 @@ suite =
             [ test "It returns the current working operand of the underlying RPN expression"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 3
+                        |> SY.appendOperand "3"
                         |> SY.appendOperator Add
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Multiply
-                        |> SY.appendOperand 2
+                        |> SY.appendOperand "2"
                         |> SY.currentOperand
-                        |> Expect.equal 2
+                        |> Expect.equal "2"
                 )
             , test "It doesn't get tripped up on operators"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 3
+                        |> SY.appendOperand "3"
                         |> SY.appendOperator Add
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Multiply
                         |> SY.currentOperand
-                        |> Expect.equal 4
+                        |> Expect.equal "4"
                 )
             , test "It defaults to 0"
                 (\_ ->
                     SY.init
                         |> SY.currentOperand
-                        |> Expect.equal 0
+                        |> Expect.equal "0"
                 )
             ]
         , describe "currentOperator"
             [ test "It returns the current working operator of the underlying RPN expression"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 3
+                        |> SY.appendOperand "3"
                         |> SY.appendOperator Add
-                        |> SY.appendOperand 4
+                        |> SY.appendOperand "4"
                         |> SY.appendOperator Multiply
-                        |> SY.appendOperand 2
+                        |> SY.appendOperand "2"
                         |> SY.currentOperator
                         |> Expect.equal (Just Multiply)
                 )
             , test "It returns Nothing if there are no operators"
                 (\_ ->
                     SY.init
-                        |> SY.appendOperand 3
+                        |> SY.appendOperand "3"
                         |> SY.currentOperator
                         |> Expect.equal Nothing
                 )


### PR DESCRIPTION
For the same reasons as previously, managing the application state through strings is much easier when it comes appending operands and mutations like appending a decimal point.